### PR TITLE
GPUAdapter fallback

### DIFF
--- a/src/q5-webgpu-canvas.js
+++ b/src/q5-webgpu-canvas.js
@@ -552,7 +552,10 @@ Q5.initWebGPU = async () => {
 	}
 	if (!Q5.device) {
 		let adapter = await navigator.gpu.requestAdapter();
-		if (!adapter) throw new Error('No appropriate GPUAdapter found.');
+		if (!adapter){
+			console.warn('No appropriate GPUAdapter found, Vulkan may need to be enabled. Falling back...');
+			return false;
+		}
 		Q5.device = await adapter.requestDevice();
 	}
 	return true;


### PR DESCRIPTION
Sketches that use WebGPU currently do not fall back to q52d in the event that WebGPU is "available", but the system cannot find an adapter. This makes the code correctly `return false` to fall back to 2d.

![image](https://github.com/user-attachments/assets/d9140807-b1e7-433f-8993-9e45599ed3c6)

This happens on some Linux Wayland systems:
![image](https://github.com/user-attachments/assets/9d837efe-1c37-4040-a6da-077ac375eef3)

(including mine)