### PR TITLE
Fix prior mouse updating.

### DIFF
--- a/src/q5-input.js
+++ b/src/q5-input.js
@@ -68,9 +68,6 @@ Q5.modules.input = ($, q) => {
 		pointer.y = y;
 
 		if (e.isPrimary || !e.pointerId) {
-			q.pmouseX = q.mouseX;
-			q.pmouseY = q.mouseY;
-
 			if (document.pointerLockElement) {
 				q.mouseX += e.movementX;
 				q.mouseY += e.movementY;


### PR DESCRIPTION
This would incorrectly update the mouse to move based on the frame updates and not our draw events. You can test this using a simple draw loop.
make a var that stores the last mouse pos, and compare it to the pmouse. They do not equal each other.
The behavior in normal p5 is that they equal each other.