### PR TITLE
remove accents from es.d.ts and documentation

### DIFF
--- a/lang/es/learn/advanced.md
+++ b/lang/es/learn/advanced.md
@@ -16,7 +16,7 @@ Funcion constructora. Crea una instancia de Q5.
 ```js
 let q = new Q5('namespace');
 q.crearLienzo(200, 100);
-q.círculo(100, 50, 20);
+q.circulo(100, 50, 20);
 ```
 
 ## Q5.version
@@ -107,7 +107,7 @@ que se pueden dibujar en una sola llamada de dibujo.
 Un límite de asignación de memoria WebGPU.
 
 El número máximo de elipses
-(llamadas a `elipse`, `círculo`, y `arco`)
+(llamadas a `elipse`, `circulo`, y `arco`)
 que se pueden dibujar en una sola llamada de dibujo.
 
 ```
@@ -148,7 +148,7 @@ q.crearLienzo(200, 100);
 
 q.dibujar = () => {
 	q.fondo(0.8);
-	q.círculo(q.ratónX, 0, 80);
+	q.circulo(q.ratonX, 0, 80);
 };
 ```
 
@@ -172,7 +172,7 @@ Q5.addHook('predraw', function () {
 });
 
 q5.dibujar = function () {
-	círculo(ratónX, ratónY, 80);
+	circulo(ratonX, ratonY, 80);
 };
 ```
 

--- a/lang/es/learn/color.md
+++ b/lang/es/learn/color.md
@@ -43,7 +43,7 @@ let botella = color(0.35, 0.39, 1, 0.4);
 relleno(botella);
 trazo(botella);
 grosorTrazo(30);
-círculo(0, 0, 155);
+circulo(0, 0, 155);
 ```
 
 ```js
@@ -53,7 +53,7 @@ let c = color(0.8, 0.2);
 
 q5.dibujar = function () {
 	fondo(c);
-	círculo(ratónX, ratónY, 50);
+	circulo(ratonX, ratonY, 50);
 	c.g = (c.g + 0.005) % 1;
 };
 ```
@@ -66,7 +66,7 @@ let c = color(0, 1, 1, 0.2);
 
 q5.dibujar = function () {
 	relleno(c);
-	círculo(ratónX, ratónY, 50);
+	circulo(ratonX, ratonY, 50);
 };
 ```
 
@@ -94,7 +94,7 @@ let botella = color(90, 100, 255, 100);
 relleno(botella);
 trazo(botella);
 grosorTrazo(30);
-círculo(100, 100, 155);
+circulo(100, 100, 155);
 ```
 
 ```js
@@ -104,7 +104,7 @@ let c = color(200, 50);
 
 function dibujar() {
 	fondo(c);
-	círculo(ratónX, ratónY, 50);
+	circulo(ratonX, ratonY, 50);
 	c.g = (c.g + 1) % 256;
 }
 ```
@@ -117,7 +117,7 @@ let c = color(0, 255, 255, 50);
 
 function dibujar() {
 	relleno(c);
-	círculo(ratónX, ratónY, 50);
+	circulo(ratonX, ratonY, 50);
 }
 ```
 
@@ -489,7 +489,7 @@ fondo('crimson');
 ```js
 q5.dibujar = function () {
 	fondo(0.5, 0.2);
-	círculo(ratónX, ratónY, 20);
+	circulo(ratonX, ratonY, 20);
 };
 ```
 
@@ -503,7 +503,7 @@ fondo('crimson');
 ```js
 function dibujar() {
 	fondo(128, 32);
-	círculo(ratónX, ratónY, 20);
+	circulo(ratonX, ratonY, 20);
 }
 ```
 

--- a/lang/es/learn/core.md
+++ b/lang/es/learn/core.md
@@ -29,7 +29,7 @@ Ten en cuenta que en este ejemplo, el círculo se encuentra en la posición [0, 
 ```js
 await Lienzo(200, 100);
 fondo('silver');
-círculo(0, 0, 80);
+circulo(0, 0, 80);
 ```
 
 ### c2d
@@ -37,7 +37,7 @@ círculo(0, 0, 80);
 ```js
 crearLienzo(200, 100);
 fondo('silver');
-círculo(0, 0, 80);
+circulo(0, 0, 80);
 ```
 
 ## dibujar
@@ -49,7 +49,7 @@ Función a declarar. Se ejecutará 60 veces por segundo de forma predeterminada.
 ```js
 q5.dibujar = function () {
 	fondo('silver');
-	círculo(ratónX, ratónY, 80);
+	circulo(ratonX, ratonY, 80);
 };
 ```
 
@@ -58,7 +58,7 @@ q5.dibujar = function () {
 ```js
 function dibujar() {
 	fondo('silver');
-	círculo(ratónX, ratónY, 80);
+	circulo(ratonX, ratonY, 80);
 }
 ```
 
@@ -76,8 +76,8 @@ Para acceder a las herramientas del navegador (DevTools) generalmente es con cli
 
 ```js
 q5.dibujar = function () {
-	círculo(ratónX, ratónY, 80);
-	log('El ratón está en:', ratónX, ratónY);
+	circulo(ratonX, ratonY, 80);
+	log('El ratón está en:', ratonX, ratonY);
 };
 ```
 
@@ -85,7 +85,7 @@ q5.dibujar = function () {
 
 ```js
 function dibujar() {
-	círculo(ratónX, ratónY, 80);
-	log('El ratón está en:', ratónX, ratónY);
+	circulo(ratonX, ratonY, 80);
+	log('El ratón está en:', ratonX, ratonY);
 }
 ```

--- a/lang/es/learn/display.md
+++ b/lang/es/learn/display.md
@@ -1,6 +1,6 @@
 # visualización
 
-## modoVisualización
+## modoVisualizacion
 
 Personaliza cómo se presenta tu lienzo.
 
@@ -15,9 +15,9 @@ Personaliza cómo se presenta tu lienzo.
 ```js
 await Lienzo(50, 25);
 
-modoVisualización(CENTRO, PIXELADO, 4);
+modoVisualizacion(CENTRO, PIXELADO, 4);
 
-círculo(0, 0, 16);
+circulo(0, 0, 16);
 ```
 
 ### c2d
@@ -25,27 +25,27 @@ círculo(0, 0, 16);
 ```js
 crearLienzo(50, 25);
 
-modoVisualización(CENTRO, PIXELADO, 4);
+modoVisualizacion(CENTRO, PIXELADO, 4);
 
-círculo(25, 12.5, 16);
+circulo(25, 12.5, 16);
 ```
 
 ## MAXIMIZADO
 
-Una configuración de `modoVisualización`.
+Una configuración de `modoVisualizacion`.
 
 El lienzo se escalará para llenar el elemento padre,
 con bandas negras si es necesario para preservar su relación de aspecto.
 
 ## SUAVE
 
-Una calidad de renderizado de `modoVisualización`.
+Una calidad de renderizado de `modoVisualizacion`.
 
 Se usa escalado suave si el lienzo se escala.
 
 ## PIXELADO
 
-Una calidad de renderizado de `modoVisualización`.
+Una calidad de renderizado de `modoVisualizacion`.
 
 Los píxeles se renderizan como cuadrados nítidos si el lienzo se escala.
 
@@ -117,7 +117,7 @@ El ancho del lienzo.
 
 ```js
 await Lienzo(200, 120);
-círculo(0, 0, ancho);
+circulo(0, 0, ancho);
 ```
 
 ## alto
@@ -128,7 +128,7 @@ El alto del lienzo.
 
 ```js
 await Lienzo(200, 80);
-círculo(0, 0, alto);
+circulo(0, 0, alto);
 ```
 
 ## medioAncho
@@ -139,7 +139,7 @@ La mitad del ancho del lienzo.
 
 ```js
 await Lienzo(200, 80);
-círculo(0, 0, medioAncho);
+circulo(0, 0, medioAncho);
 ```
 
 ## medioAlto
@@ -150,7 +150,7 @@ La mitad del alto del lienzo.
 
 ```js
 await Lienzo(200, 80);
-círculo(0, 0, medioAlto);
+circulo(0, 0, medioAlto);
 ```
 
 ## lienzo
@@ -228,7 +228,7 @@ Detiene el bucle de dibujo.
 
 ```js
 q5.dibujar = function () {
-	círculo(cuadroActual * 5 - 100, 0, 80);
+	circulo(cuadroActual * 5 - 100, 0, 80);
 	pausar();
 };
 ```
@@ -237,7 +237,7 @@ q5.dibujar = function () {
 
 ```js
 function dibujar() {
-	círculo(cuadroActual * 5, 100, 80);
+	circulo(cuadroActual * 5, 100, 80);
 	pausar();
 }
 ```
@@ -260,7 +260,7 @@ await Lienzo(200);
 pausar();
 
 q5.dibujar = function () {
-	círculo(cuadroActual * 5 - 100, 0, 80);
+	circulo(cuadroActual * 5 - 100, 0, 80);
 };
 q5.alPresionarRatón = function () {
 	redibujar(10);
@@ -274,7 +274,7 @@ crearLienzo(200);
 pausar();
 
 function dibujar() {
-	círculo(cuadroActual * 5, 100, 80);
+	circulo(cuadroActual * 5, 100, 80);
 }
 function alPresionarRatón() {
 	redibujar(10);
@@ -292,7 +292,7 @@ await Lienzo(200);
 pausar();
 
 q5.dibujar = function () {
-	círculo(cuadroActual * 5 - 100, 0, 80);
+	circulo(cuadroActual * 5 - 100, 0, 80);
 };
 q5.alPresionarRatón = function () {
 	reanudar();
@@ -306,7 +306,7 @@ crearLienzo(200);
 pausar();
 
 function dibujar() {
-	círculo(cuadroActual * 5, 100, 80);
+	circulo(cuadroActual * 5, 100, 80);
 }
 function alPresionarRatón() {
 	reanudar();
@@ -333,10 +333,10 @@ de tu navegador web para un análisis de rendimiento más preciso.
 q5.dibujar = function () {
 	fondo(0.8);
 
-	if (ratónPresionado) frecuenciaRefresco(10);
+	if (ratonPresionado) frecuenciaRefresco(10);
 	else frecuenciaRefresco(60);
 
-	círculo((cuadroActual % 200) - 100, 0, 80);
+	circulo((cuadroActual % 200) - 100, 0, 80);
 };
 ```
 
@@ -354,10 +354,10 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 
-	if (ratónPresionado) frecuenciaRefresco(10);
+	if (ratonPresionado) frecuenciaRefresco(10);
 	else frecuenciaRefresco(60);
 
-	círculo(cuadroActual % 200, 100, 80);
+	circulo(cuadroActual % 200, 100, 80);
 }
 ```
 
@@ -449,7 +449,7 @@ la función `dibujar` se ejecuta.
 ```js
 function dibujar() {
 	fondo(200);
-	círculo(cuadroActual % 200, 100, 80);
+	circulo(cuadroActual % 200, 100, 80);
 }
 
 function postProcesar() {
@@ -457,7 +457,7 @@ function postProcesar() {
 }
 ```
 
-## densidadPíxeles
+## densidadPixeles
 
 Establece la densidad de píxeles del lienzo.
 
@@ -471,8 +471,8 @@ Establece la densidad de píxeles del lienzo.
 ```js
 await Lienzo(200, 100);
 fondo(0.8);
-densidadPíxeles(1);
-círculo(0, 0, 80);
+densidadPixeles(1);
+circulo(0, 0, 80);
 ```
 
 ### c2d
@@ -480,11 +480,11 @@ círculo(0, 0, 80);
 ```js
 crearLienzo(200, 100);
 fondo(200);
-densidadPíxeles(1);
-círculo(100, 50, 80);
+densidadPixeles(1);
+circulo(100, 50, 80);
 ```
 
-## densidadVisualización
+## densidadVisualizacion
 
 Devuelve la densidad de visualización actual.
 
@@ -500,7 +500,7 @@ En la mayoría de pantallas modernas, este valor será 2 o 3.
 await Lienzo(200, 100);
 fondo(0.8);
 tamañoTexto(64);
-texto(densidadVisualización(), -90, 6);
+texto(densidadVisualizacion(), -90, 6);
 ```
 
 ### c2d
@@ -509,7 +509,7 @@ texto(densidadVisualización(), -90, 6);
 crearLienzo(200, 100);
 fondo(200);
 tamañoTexto(64);
-texto(densidadVisualización(), 10, 20);
+texto(densidadVisualizacion(), 10, 20);
 ```
 
 ## deltaTiempo
@@ -542,7 +542,7 @@ q5.dibujar = function () {
 
 	x += deltaTiempo * 0.2;
 	if (x > 100) x = -100;
-	círculo(x, 0, 20);
+	circulo(x, 0, 20);
 };
 ```
 
@@ -563,7 +563,7 @@ function dibujar() {
 	frecuenciaRefresco(aleatorio(30, 60));
 
 	x += deltaTiempo * 0.2;
-	círculo(x % 200, 100, 20);
+	circulo(x % 200, 100, 20);
 }
 ```
 

--- a/lang/es/learn/dom.md
+++ b/lang/es/learn/dom.md
@@ -96,7 +96,7 @@ enlace.addEventListener('mouseover', () => {
 });
 ```
 
-## crearBotón
+## crearBoton
 
 Crea un elemento de botón.
 
@@ -109,7 +109,7 @@ Crea un elemento de botón.
 ```js
 await Lienzo(200, 100);
 
-let btn = crearBotón('¡Clic aqui!');
+let btn = crearBoton('¡Clic aqui!');
 
 btn.addEventListener('click', () => {
 	fondo(aleatorio(0.4, 1));
@@ -121,7 +121,7 @@ btn.addEventListener('click', () => {
 ```js
 crearLienzo(200, 100);
 
-let btn = crearBotón('¡Click aqui!');
+let btn = crearBoton('¡Click aqui!');
 
 btn.addEventListener('click', () => {
 	fondo(aleatorio(100, 255));
@@ -307,7 +307,7 @@ let p = crearP('¡Hola, mundo!');
 p.style.color = 'pink';
 ```
 
-## crearOpciónes
+## crearOpciones
 
 Crea un grupo de botones de radio.
 
@@ -325,13 +325,13 @@ Usa la propiedad `value` para obtener o establecer el valor del botón de radio 
 ```js
 await Lienzo(200, 160);
 
-let radio = crearOpciónes();
+let radio = crearOpciones();
 radio.option('cuadrado', '1').option('círculo', '2');
 
 q5.dibujar = function () {
 	fondo(0.8);
 	if (radio.value == '1') cuadrado(-40, -40, 80);
-	if (radio.value == '2') círculo(0, 0, 80);
+	if (radio.value == '2') circulo(0, 0, 80);
 };
 ```
 
@@ -340,17 +340,17 @@ q5.dibujar = function () {
 ```js
 crearLienzo(200, 160);
 
-let radio = crearOpciónes();
+let radio = crearOpciones();
 radio.option('cuadrado', '1').option('círculo', '2');
 
 function dibujar() {
 	fondo(200);
 	if (radio.value == '1') cuadrado(75, 25, 80);
-	if (radio.value == '2') círculo(100, 50, 80);
+	if (radio.value == '2') circulo(100, 50, 80);
 }
 ```
 
-## crearSelección
+## crearSeleccion
 
 Crea un elemento de selección (select).
 
@@ -374,7 +374,7 @@ cadena o un array de cadenas.
 ```js
 await Lienzo(200, 100);
 
-let sel = crearSelección('Seleccionar un opcion');
+let sel = crearSeleccion('Seleccionar un opcion');
 sel.option('Red', '#f55').option('Green', '#5f5');
 
 sel.addEventListener('change', () => {
@@ -387,7 +387,7 @@ sel.addEventListener('change', () => {
 ```js
 crearLienzo(200, 100);
 
-let sel = crearSelección('Seleccionar un opcion');
+let sel = crearSeleccion('Seleccionar un opcion');
 sel.option('Red', '#f55').option('Green', '#5f5');
 
 sel.addEventListener('change', () => {

--- a/lang/es/learn/es.d.ts
+++ b/lang/es/learn/es.d.ts
@@ -10,7 +10,7 @@ declare global {
 
 	// 🧑‍🎨 shapes
 
-	function círculo(x: number, y: number, diámetro: number): void;
+	function circulo(x: number, y: number, diametro: number): void;
 
 	function elipse(x: number, y: number, ancho: number, alto?: number): void;
 
@@ -20,9 +20,9 @@ declare global {
 
 	function punto(x: number, y: number): void;
 
-	function línea(x1: number, y1: number, x2: number, y2: number): void;
+	function linea(x1: number, y1: number, x2: number, y2: number): void;
 
-	function cápsula(x1: number, y1: number, x2: number, y2: number, r: number): void;
+	function capsula(x1: number, y1: number, x2: number, y2: number, r: number): void;
 
 	function modoRect(modo: string): void;
 
@@ -85,11 +85,11 @@ declare global {
 
 	function establecer(x: number, y: number, val: any): void;
 
-	var píxeles: number[];
+	var pixeles: number[];
 
-	function cargarPíxeles(): void;
+	function cargarPixeles(): void;
 
-	function actualizarPíxeles(): void;
+	function actualizarPixeles(): void;
 
 	function filtro(tipo: string, valor?: number): void;
 
@@ -111,7 +111,7 @@ declare global {
 
 	function crearImagen(w: number, h: number, opt?: any): Q5.Imagen;
 
-	function crearGráficos(w: number, h: number, opt?: any): Q5;
+	function crearGraficos(w: number, h: number, opt?: any): Q5;
 
 	// 📘 text
 
@@ -127,7 +127,7 @@ declare global {
 
 	function estiloTexto(estilo: 'normal' | 'italic' | 'bold' | 'bolditalic'): void;
 
-	function alineaciónTexto(horiz: 'left' | 'center' | 'right', vert?: 'top' | 'middle' | 'bottom' | 'alphabetic'): void;
+	function alineacionTexto(horiz: 'left' | 'center' | 'right', vert?: 'top' | 'middle' | 'bottom' | 'alphabetic'): void;
 
 	function pesoTexto(peso: number | string): void;
 
@@ -165,25 +165,25 @@ declare global {
 
 	// 🖲️ input
 
-	let ratónX: number;
+	let ratonX: number;
 
-	let ratónY: number;
+	let ratonY: number;
 
-	let pRatónX: number;
+	let pRatonX: number;
 
-	let pRatónY: number;
+	let pRatonY: number;
 
-	let botónRatón: string;
+	let botonRaton: string;
 
-	let ratónPresionado: boolean;
+	let ratonPresionado: boolean;
 
-	function alPresionarRatón(): void;
+	function alPresionarRaton(): void;
 
-	function alSoltarRatón(): void;
+	function alSoltarRaton(): void;
 
-	function alMoverRatón(): void;
+	function alMoverRaton(): void;
 
-	function alArrastrarRatón(): void;
+	function alArrastrarRaton(): void;
 
 	function dobleClic(): void;
 
@@ -209,7 +209,7 @@ declare global {
 
 	function sinCursor(): void;
 
-	function ruedaRatón(evento: any): void;
+	function ruedaRaton(evento: any): void;
 
 	let movidoX: number;
 
@@ -271,9 +271,9 @@ declare global {
 
 	function modoMezcla(val: string): void;
 
-	function terminaciónTrazo(val: CanvasLineCap): void;
+	function terminacionTrazo(val: CanvasLineCap): void;
 
-	function uniónTrazo(val: CanvasLineJoin): void;
+	function unionTrazo(val: CanvasLineJoin): void;
 
 	function borrar(rellenoAlfa?: number, trazoAlfa?: number): void;
 
@@ -317,7 +317,7 @@ declare global {
 
 	// 💻 display
 
-	function modoVisualización(modo: string, calidadRender: string, escala: string | number): void;
+	function modoVisualizacion(modo: string, calidadRender: string, escala: string | number): void;
 
 	const MAXIMIZADO: 'maxed';
 
@@ -359,9 +359,9 @@ declare global {
 
 	function postProcesar(): void;
 
-	function densidadPíxeles(v: number): number;
+	function densidadPixeles(v: number): number;
 
-	function densidadVisualización(): number;
+	function densidadVisualizacion(): number;
 
 	var deltaTiempo: number;
 
@@ -381,7 +381,7 @@ declare global {
 
 	function mapa(val: number, inicio1: number, fin1: number, inicio2: number, fin2: number): number;
 
-	function modoÁngulo(modo: 'degrees' | 'radians'): void;
+	function modoAngulo(modo: 'degrees' | 'radians'): void;
 
 	function radianes(grados: number): number;
 
@@ -475,7 +475,7 @@ declare global {
 
 	function crearA(href: string, texto?: string): HTMLAnchorElement;
 
-	function crearBotón(contenido?: string): HTMLButtonElement;
+	function crearBoton(contenido?: string): HTMLButtonElement;
 
 	function crearCasilla(etiqueta?: string, marcado?: boolean): HTMLInputElement;
 
@@ -487,9 +487,9 @@ declare global {
 
 	function crearP(contenido?: string): HTMLParagraphElement;
 
-	function crearOpciónes(nombreGrupo?: string): HTMLDivElement;
+	function crearOpciones(nombreGrupo?: string): HTMLDivElement;
 
-	function crearSelección(placeholder?: string): HTMLSelectElement;
+	function crearSeleccion(placeholder?: string): HTMLSelectElement;
 
 	function crearDeslizador(min: number, max: number, valor?: number, paso?: number): HTMLInputElement;
 
@@ -507,11 +507,11 @@ declare global {
 
 	function grabar(): void;
 
-	function pausarGrabación(): void;
+	function pausarGrabacion(): void;
 
-	function borrarGrabación(): void;
+	function borrarGrabacion(): void;
 
-	function guardarGrabación(nombreArchivo: string): void;
+	function guardarGrabacion(nombreArchivo: string): void;
 
 	var grabando: boolean;
 
@@ -547,7 +547,7 @@ declare global {
 
 	function año(): number;
 
-	function día(): number;
+	function dia(): number;
 
 	function hora(): number;
 
@@ -602,7 +602,7 @@ declare global {
 
 		slerp(v: Vector, amt: number): Vector;
 
-		static desdeÁngulo(angulo: number, longitud?: number): Vector;
+		static desdeAngulo(angulo: number, longitud?: number): Vector;
 	}
 
 	// 🖌️ shaping
@@ -621,15 +621,15 @@ declare global {
 
 	function terminarContorno(): void;
 
-	function vértice(x: number, y: number): void;
+	function vertice(x: number, y: number): void;
 
-	function vérticeBezier(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void;
+	function verticeBezier(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void;
 
-	function vérticeCuadrático(cp1x: number, cp1y: number, x: number, y: number): void;
+	function verticeCuadratico(cp1x: number, cp1y: number, x: number, y: number): void;
 
 	function bezier(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number, x4: number, y4: number): void;
 
-	function triángulo(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void;
+	function triangulo(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void;
 
 	function quad(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number, x4: number, y4: number): void;
 
@@ -666,7 +666,7 @@ declare global {
 	class Q5 {
 		constructor(scope?: string | Function, parent?: HTMLElement);
 
-		static versión: string;
+		static version: string;
 
 		static lang: string;
 
@@ -707,13 +707,13 @@ declare global {
 		postProcesar(): void;
 		Lienzo: typeof Lienzo;
 		log: typeof log;
-		círculo: typeof círculo;
+		circulo: typeof circulo;
 		elipse: typeof elipse;
 		rect: typeof rect;
 		cuadrado: typeof cuadrado;
 		punto: typeof punto;
-		línea: typeof línea;
-		cápsula: typeof cápsula;
+		linea: typeof linea;
+		capsula: typeof capsula;
 		modoRect: typeof modoRect;
 		modoEliptico: typeof modoEliptico;
 		cargarImagen: typeof cargarImagen;
@@ -731,18 +731,18 @@ declare global {
 		insertado: typeof insertado;
 		obtener: typeof obtener;
 		establecer: typeof establecer;
-		cargarPíxeles: typeof cargarPíxeles;
-		actualizarPíxeles: typeof actualizarPíxeles;
+		cargarPixeles: typeof cargarPixeles;
+		actualizarPixeles: typeof actualizarPixeles;
 		filtro: typeof filtro;
 		crearImagen: typeof crearImagen;
-		crearGráficos: typeof crearGráficos;
+		crearGraficos: typeof crearGraficos;
 		texto: typeof texto;
 		cargarFuente: typeof cargarFuente;
 		fuenteTexto: typeof fuenteTexto;
 		tamañoTexto: typeof tamañoTexto;
 		interlineado: typeof interlineado;
 		estiloTexto: typeof estiloTexto;
-		alineaciónTexto: typeof alineaciónTexto;
+		alineacionTexto: typeof alineacionTexto;
 		pesoTexto: typeof pesoTexto;
 		anchoTexto: typeof anchoTexto;
 		ascensoTexto: typeof ascensoTexto;
@@ -750,10 +750,10 @@ declare global {
 		crearImagenTexto: typeof crearImagenTexto;
 		imagenTexto: typeof imagenTexto;
 		nf: typeof nf;
-		alPresionarRatón: typeof alPresionarRatón;
-		alSoltarRatón: typeof alSoltarRatón;
-		alMoverRatón: typeof alMoverRatón;
-		alArrastrarRatón: typeof alArrastrarRatón;
+		alPresionarRaton: typeof alPresionarRaton;
+		alSoltarRaton: typeof alSoltarRaton;
+		alMoverRaton: typeof alMoverRaton;
+		alArrastrarRaton: typeof alArrastrarRaton;
 		dobleClic: typeof dobleClic;
 		teclaEstaPresionada: typeof teclaEstaPresionada;
 		alPresionarTecla: typeof alPresionarTecla;
@@ -763,7 +763,7 @@ declare global {
 		alMoverToque: typeof alMoverToque;
 		cursor: typeof cursor;
 		sinCursor: typeof sinCursor;
-		ruedaRatón: typeof ruedaRatón;
+		ruedaRaton: typeof ruedaRaton;
 		bloqueoPuntero: typeof bloqueoPuntero;
 		color: typeof color;
 		modoColor: typeof modoColor;
@@ -778,8 +778,8 @@ declare global {
 		sinSombra: typeof sinSombra;
 		cajaSombra: typeof cajaSombra;
 		modoMezcla: typeof modoMezcla;
-		terminaciónTrazo: typeof terminaciónTrazo;
-		uniónTrazo: typeof uniónTrazo;
+		terminacionTrazo: typeof terminacionTrazo;
+		unionTrazo: typeof unionTrazo;
 		borrar: typeof borrar;
 		noBorrar: typeof noBorrar;
 		guardarEstilos: typeof guardarEstilos;
@@ -798,7 +798,7 @@ declare global {
 		recuperarMatriz: typeof recuperarMatriz;
 		guardar: typeof guardar;
 		recuperar: typeof recuperar;
-		modoVisualización: typeof modoVisualización;
+		modoVisualizacion: typeof modoVisualizacion;
 		pantallaCompleta: typeof pantallaCompleta;
 		redimensionarLienzo: typeof redimensionarLienzo;
 		pausar: typeof pausar;
@@ -807,14 +807,14 @@ declare global {
 		frecuenciaRefresco: typeof frecuenciaRefresco;
 		obtenerTasaFotogramasObjetivo: typeof obtenerTasaFotogramasObjetivo;
 		obtenerFPS: typeof obtenerFPS;
-		densidadPíxeles: typeof densidadPíxeles;
-		densidadVisualización: typeof densidadVisualización;
+		densidadPixeles: typeof densidadPixeles;
+		densidadVisualizacion: typeof densidadVisualizacion;
 		aleatorio: typeof aleatorio;
 		flu: typeof flu;
 		ruido: typeof ruido;
 		dist: typeof dist;
 		mapa: typeof mapa;
-		modoÁngulo: typeof modoÁngulo;
+		modoAngulo: typeof modoAngulo;
 		radianes: typeof radianes;
 		grados: typeof grados;
 		interpolar: typeof interpolar;
@@ -845,14 +845,14 @@ declare global {
 		iniciarAudioUsuario: typeof iniciarAudioUsuario;
 		crearElemento: typeof crearElemento;
 		crearA: typeof crearA;
-		crearBotón: typeof crearBotón;
+		crearBoton: typeof crearBoton;
 		crearCasilla: typeof crearCasilla;
 		crearSelectorColor: typeof crearSelectorColor;
 		crearImg: typeof crearImg;
 		crearEntrada: typeof crearEntrada;
 		crearP: typeof crearP;
-		crearOpciónes: typeof crearOpciónes;
-		crearSelección: typeof crearSelección;
+		crearOpciones: typeof crearOpciones;
+		crearSeleccion: typeof crearSeleccion;
 		crearDeslizador: typeof crearDeslizador;
 		crearVideo: typeof crearVideo;
 		crearCaptura: typeof crearCaptura;
@@ -860,9 +860,9 @@ declare global {
 		encontrarElementos: typeof encontrarElementos;
 		crearGrabadora: typeof crearGrabadora;
 		recordar: typeof grabar;
-		pausarGrabación: typeof pausarGrabación;
-		borrarGrabación: typeof borrarGrabación;
-		guardarGrabación: typeof guardarGrabación;
+		pausarGrabacion: typeof pausarGrabacion;
+		borrarGrabacion: typeof borrarGrabacion;
+		guardarGrabacion: typeof guardarGrabacion;
 		cargar: typeof cargar;
 		cargarTexto: typeof cargarTexto;
 		cargarJSON: typeof cargarJSON;
@@ -876,7 +876,7 @@ declare global {
 		eliminarItem: typeof eliminarItem;
 		limpiarAlmacenamiento: typeof limpiarAlmacenamiento;
 		año: typeof año;
-		día: typeof día;
+		dia: typeof dia;
 		hora: typeof hora;
 		minuto: typeof minuto;
 		segundo: typeof segundo;
@@ -896,8 +896,8 @@ declare global {
 			enmascarar(img: Q5.Imagen): void;
 			recortar(): Q5.Imagen;
 			filtro(tipo: string, valor?: number): void;
-			cargarPíxeles(): void;
-			actualizarPíxeles(): void;
+			cargarPixeles(): void;
+			actualizarPixeles(): void;
 			guardar(nombreArchivo?: string): void;
 		}
 

--- a/lang/es/learn/image.md
+++ b/lang/es/learn/image.md
@@ -414,10 +414,10 @@ Recupera una subsección de una imagen o lienzo como una nueva Imagen Q5
 o el color de un píxel en la imagen o lienzo.
 
 Si solo se especifican x e y, esta función devuelve el color del píxel
-en la coordenada dada en formato de array `[R, G, B, A]`. Si `cargarPíxeles`
+en la coordenada dada en formato de array `[R, G, B, A]`. Si `cargarPixeles`
 nunca se ha ejecutado, es ejecutado por esta función.
 
-Si haces cambios en el lienzo o imagen, debes llamar a `cargarPíxeles`
+Si haces cambios en el lienzo o imagen, debes llamar a `cargarPixeles`
 antes de usar esta función para obtener los datos de color actuales.
 
 No aplicable a lienzos WebGPU.
@@ -447,11 +447,11 @@ imagen(recortada, -100, -100, 200, 200);
 function dibujar() {
 	fondo(200);
 	sinTrazo();
-	círculo(100, 100, frameCount % 200);
+	circulo(100, 100, frameCount % 200);
 
-	cargarPíxeles();
-	let col = obtener(ratónX, ratónY);
-	texto(col, ratónX, ratónY);
+	cargarPixeles();
+	let col = obtener(ratonX, ratonY);
+	texto(col, ratonX, ratonY);
 }
 ```
 
@@ -473,7 +473,7 @@ Establece el color de un píxel en la imagen o lienzo. El modo de color debe ser
 O si se proporciona un lienzo o imagen, se dibuja encima de la
 imagen o lienzo de destino, ignorando su configuración de tinte.
 
-Ejecuta `actualizarPíxeles` para aplicar los cambios.
+Ejecuta `actualizarPixeles` para aplicar los cambios.
 
 No aplicable a lienzos WebGPU.
 
@@ -493,7 +493,7 @@ let img = crearImagen(50, 50);
 
 q5.dibujar = function () {
 	img.establecer(aleatorio(50), aleatorio(50), c);
-	img.actualizarPíxeles();
+	img.actualizarPixeles();
 
 	fondo(img);
 };
@@ -507,15 +507,15 @@ let c = color('lime');
 
 function dibujar() {
 	establecer(aleatorio(200), aleatorio(200), c);
-	actualizarPíxeles();
+	actualizarPixeles();
 }
 ```
 
-## píxeles
+## pixeles
 
 Array de datos de color de píxeles de un lienzo o imagen.
 
-Vacío por defecto, obtener el dato ejecutando `cargarPíxeles`.
+Vacío por defecto, obtener el dato ejecutando `cargarPixeles`.
 
 Cada píxel está representado por cuatro valores consecutivos en el array,
 correspondientes a sus canales rojo, verde, azul y alfa.
@@ -524,9 +524,9 @@ Los datos del píxel superior izquierdo están al principio del array
 y los datos del píxel inferior derecho están al final, yendo de
 izquierda a derecha y de arriba a abajo.
 
-## cargarPíxeles
+## cargarPixeles
 
-Carga datos de píxeles en `píxeles` desde el lienzo o imagen.
+Carga datos de píxeles en `pixeles` desde el lienzo o imagen.
 
 El ejemplo a continuación establece el canal verde de algunos píxeles
 a un valor aleatorio.
@@ -540,11 +540,11 @@ frecuenciaRefresco(5);
 let icono = cargarImagen('/q5js_icon.png');
 
 q5.dibujar = function () {
-	icono.cargarPíxeles();
-	for (let i = 0; i < icono.píxeles.length; i += 16) {
-		icono.píxeles[i + 1] = aleatorio(1);
+	icono.cargarPixeles();
+	for (let i = 0; i < icono.pixeles.length; i += 16) {
+		icono.pixeles[i + 1] = aleatorio(1);
 	}
-	icono.actualizarPíxeles();
+	icono.actualizarPixeles();
 	fondo(icono);
 };
 ```
@@ -556,18 +556,18 @@ frecuenciaRefresco(5);
 let icono = cargarImagen('/q5js_icon.png');
 
 function dibujar() {
-	icono.cargarPíxeles();
-	for (let i = 0; i < icono.píxeles.length; i += 16) {
-		icono.píxeles[i + 1] = aleatorio(255);
+	icono.cargarPixeles();
+	for (let i = 0; i < icono.pixeles.length; i += 16) {
+		icono.pixeles[i + 1] = aleatorio(255);
 	}
-	icono.actualizarPíxeles();
+	icono.actualizarPixeles();
 	fondo(icono);
 }
 ```
 
-## actualizarPíxeles
+## actualizarPixeles
 
-Aplica cambios en el array `píxeles` al lienzo o imagen.
+Aplica cambios en el array `pixeles` al lienzo o imagen.
 
 No aplicable a lienzos WebGPU.
 
@@ -583,7 +583,7 @@ for (let x = 0; x < 50; x += 3) {
 		img.establecer(x, y, c);
 	}
 }
-img.actualizarPíxeles();
+img.actualizarPixeles();
 
 fondo(img);
 ```
@@ -598,7 +598,7 @@ for (let x = 0; x < 200; x += 5) {
 		establecer(x, y, color('pink'));
 	}
 }
-actualizarPíxeles();
+actualizarPixeles();
 ```
 
 ## filtro
@@ -681,7 +681,7 @@ Crea una nueva imagen.
 @returns {Q5.Image}
 ```
 
-## crearGráficos
+## crearGraficos
 
 Crea un búfer de gráficos.
 

--- a/lang/es/learn/input.md
+++ b/lang/es/learn/input.md
@@ -10,9 +10,9 @@ hasta la próxima vez que se dibuja un fotograma.
 
 Reproduce sonidos o activa otra retroalimentación no visual inmediatamente
 respondiendo a eventos de entrada dentro de funciones como
-`alPresionarRatón` y `alPresionarTecla`.
+`alPresionarRaton` y `alPresionarTecla`.
 
-## ratónX
+## ratonX
 
 Posición X actual del ratón.
 
@@ -22,7 +22,7 @@ Posición X actual del ratón.
 q5.dibujar = function () {
 	fondo(0.8);
 	tamañoTexto(64);
-	texto(redondear(ratónX), -50, 20);
+	texto(redondear(ratonX), -50, 20);
 };
 ```
 
@@ -32,11 +32,11 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 	tamañoTexto(64);
-	texto(redondear(ratónX), 50, 120);
+	texto(redondear(ratonX), 50, 120);
 }
 ```
 
-## ratónY
+## ratonY
 
 Posición Y actual del ratón.
 
@@ -45,7 +45,7 @@ Posición Y actual del ratón.
 ```js
 q5.dibujar = function () {
 	fondo(0.8);
-	círculo(0, ratónY, 100);
+	circulo(0, ratonY, 100);
 };
 ```
 
@@ -54,19 +54,19 @@ q5.dibujar = function () {
 ```js
 function dibujar() {
 	fondo(200);
-	círculo(100, ratónY, 100);
+	circulo(100, ratonY, 100);
 }
 ```
 
-## pRatónX
+## pRatonX
 
 Posición X previa del ratón.
 
-## pRatónY
+## pRatonY
 
 Posición Y previa del ratón.
 
-## botónRatón
+## botonRaton
 
 El botón actual siendo presionado: 'left', 'right', 'center').
 
@@ -78,7 +78,7 @@ El valor por defecto es una cadena vacía.
 q5.dibujar = function () {
 	fondo(0.8);
 	tamañoTexto(64);
-	texto(botónRatón, -80, 20);
+	texto(botonRaton, -80, 20);
 };
 ```
 
@@ -88,19 +88,19 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 	tamañoTexto(64);
-	texto(botónRatón, 20, 120);
+	texto(botonRaton, 20, 120);
 }
 ```
 
-## ratónPresionado
+## ratonPresionado
 
-Verdadero si el ratón está actualmente presionado, falso de lo contrario.
+Verdadero si el raton está actualmente presionado, falso de lo contrario.
 
 ### webgpu
 
 ```js
 q5.dibujar = function () {
-	if (ratónPresionado) fondo(0.4);
+	if (ratonPresionado) fondo(0.4);
 	else fondo(0.8);
 };
 ```
@@ -109,12 +109,12 @@ q5.dibujar = function () {
 
 ```js
 function dibujar() {
-	if (ratónPresionado) fondo(100);
+	if (ratonPresionado) fondo(100);
 	else fondo(200);
 }
 ```
 
-## alPresionarRatón
+## alPresionarRaton
 
 Define esta función para responder a eventos de presionar el ratón.
 
@@ -124,7 +124,7 @@ Define esta función para responder a eventos de presionar el ratón.
 await Lienzo(200);
 let gris = 0.4;
 
-q5.alPresionarRatón = function () {
+q5.alPresionarRaton = function () {
 	fondo(gris);
 	gris = (gris + 0.1) % 1;
 };
@@ -136,13 +136,13 @@ q5.alPresionarRatón = function () {
 crearLienzo(200);
 let gris = 95;
 
-function alPresionarRatón() {
+function alPresionarRaton() {
 	fondo(gris % 256);
 	gris += 40;
 }
 ```
 
-## alSoltarRatón
+## alSoltarRaton
 
 Define esta función para responder a eventos de soltar el ratón.
 
@@ -152,7 +152,7 @@ Define esta función para responder a eventos de soltar el ratón.
 await Lienzo(200);
 let gris = 0.4;
 
-q5.alSoltarRatón = function () {
+q5.alSoltarRaton = function () {
 	fondo(gris);
 	gris = (gris + 0.1) % 1;
 };
@@ -164,13 +164,13 @@ q5.alSoltarRatón = function () {
 crearLienzo(200);
 let gris = 95;
 
-function alSoltarRatón() {
+function alSoltarRaton() {
 	fondo(gris % 256);
 	gris += 40;
 }
 ```
 
-## alMoverRatón
+## alMoverRaton
 
 Define esta función para responder a eventos de mover el ratón.
 
@@ -183,7 +183,7 @@ cuando el usuario arrastra su dedo en la pantalla.
 await Lienzo(200);
 let gris = 0.4;
 
-q5.alMoverRatón = function () {
+q5.alMoverRaton = function () {
 	fondo(gris);
 	gris = (gris + 0.005) % 1;
 };
@@ -195,13 +195,13 @@ q5.alMoverRatón = function () {
 crearLienzo(200);
 let gris = 95;
 
-function alMoverRatón() {
+function alMoverRaton() {
 	fondo(gris % 256);
 	gris++;
 }
 ```
 
-## alArrastrarRatón
+## alArrastrarRaton
 
 Define esta función para responder a eventos de arrastrar el ratón.
 
@@ -214,7 +214,7 @@ mientras un botón del ratón está presionado.
 await Lienzo(200);
 let gris = 0.4;
 
-q5.alArrastrarRatón = function () {
+q5.alArrastrarRaton = function () {
 	fondo(gris);
 	gris = (gris + 0.005) % 1;
 };
@@ -226,7 +226,7 @@ q5.alArrastrarRatón = function () {
 crearLienzo(200);
 let gris = 95;
 
-function alArrastrarRatón() {
+function alArrastrarRaton() {
 	fondo(gris % 256);
 	gris++;
 }
@@ -410,7 +410,7 @@ Considera usar el array `punteros` en su lugar, el cual incluye entrada de rató
 q5.dibujar = function () {
 	fondo(0.8);
 	for (let pt of punteros) {
-		círculo(pt.x, pt.y, 100);
+		circulo(pt.x, pt.y, 100);
 	}
 };
 ```
@@ -421,7 +421,7 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 	for (let pt of punteros) {
-		círculo(pt.x, pt.y, 100);
+		circulo(pt.x, pt.y, 100);
 	}
 }
 ```
@@ -566,7 +566,7 @@ crearLienzo(200, 100);
 sinCursor();
 ```
 
-## ruedaRatón
+## ruedaRaton
 
 Define esta función para responder a eventos de la rueda del ratón.
 
@@ -580,9 +580,9 @@ Devuelve true para permitir el comportamiento por defecto de desplazar la págin
 ```js
 let x = (y = 0);
 q5.dibujar = function () {
-	círculo(x, y, 10);
+	circulo(x, y, 10);
 };
-q5.ruedaRatón = function (e) {
+q5.ruedaRaton = function (e) {
 	x += e.deltaX;
 	y += e.deltaY;
 	return false;
@@ -594,9 +594,9 @@ q5.ruedaRatón = function (e) {
 ```js
 let x = (y = 100);
 function dibujar() {
-	círculo(x, y, 10);
+	circulo(x, y, 10);
 }
-function ruedaRatón(e) {
+function ruedaRaton(e) {
 	x += e.deltaX;
 	y += e.deltaY;
 	return false;
@@ -648,7 +648,7 @@ Para salir del modo de bloqueo de puntero, llama a `document.exitPointerLock()`.
 
 ```js
 q5.dibujar = function () {
-	círculo(ratónX / 10, ratónY / 10, 10);
+	circulo(ratonX / 10, ratonY / 10, 10);
 };
 
 q5.dobleClic = function () {
@@ -664,7 +664,7 @@ q5.dobleClic = function () {
 
 ```js
 function dibujar() {
-	círculo(ratónX / 10 + 100, ratónY / 10 + 100, 10);
+	circulo(ratonX / 10 + 100, ratonY / 10 + 100, 10);
 }
 
 function dobleClic() {

--- a/lang/es/learn/math.md
+++ b/lang/es/learn/math.md
@@ -23,13 +23,13 @@ fondo(0.8);
 frecuenciaRefresco(5);
 
 q5.dibujar = function () {
-	círculo(0, 0, aleatorio(200));
+	circulo(0, 0, aleatorio(200));
 };
 ```
 
 ```js
 q5.dibujar = function () {
-	círculo(aleatorio(-100, 100), aleatorio(-100, 100), 10);
+	circulo(aleatorio(-100, 100), aleatorio(-100, 100), 10);
 };
 ```
 
@@ -41,13 +41,13 @@ fondo(200);
 frecuenciaRefresco(5);
 
 function dibujar() {
-	círculo(100, 100, aleatorio(20, 200));
+	circulo(100, 100, aleatorio(20, 200));
 }
 ```
 
 ```js
 function dibujar() {
-	círculo(aleatorio(200), aleatorio(200), 10);
+	circulo(aleatorio(200), aleatorio(200), 10);
 }
 ```
 
@@ -68,7 +68,7 @@ Equivalente a `aleatorio(-cantidad, cantidad)`.
 
 ```js
 q5.dibujar = function () {
-	círculo(ratónX + flu(3), ratónY + flu(3), 5);
+	circulo(ratonX + flu(3), ratonY + flu(3), 5);
 };
 ```
 
@@ -76,7 +76,7 @@ q5.dibujar = function () {
 await Lienzo(200);
 
 q5.dibujar = function () {
-	círculo(flu(50), 0, aleatorio(50));
+	circulo(flu(50), 0, aleatorio(50));
 };
 ```
 
@@ -84,7 +84,7 @@ q5.dibujar = function () {
 
 ```js
 function dibujar() {
-	círculo(ratónX + flu(3), ratónY + flu(3), 5);
+	circulo(ratonX + flu(3), ratonY + flu(3), 5);
 }
 ```
 
@@ -93,7 +93,7 @@ let q = await Q5.WebGPU();
 crearLienzo(200, 100);
 
 q.dibujar = () => {
-	círculo(flu(50), 0, aleatorio(50));
+	circulo(flu(50), 0, aleatorio(50));
 };
 ```
 
@@ -116,17 +116,17 @@ Usa [Ruido Perlin](https://es.wikipedia.org/wiki/Ruido_Perlin) por defecto.
 q5.dibujar = function () {
 	fondo(0.8);
 	let n = ruido(frameCount * 0.01);
-	círculo(0, 0, n * 200);
+	circulo(0, 0, n * 200);
 };
 ```
 
 ```js
 q5.dibujar = function () {
 	fondo(0.8);
-	let t = (frameCount + ratónX) * 0.02;
+	let t = (frameCount + ratonX) * 0.02;
 	for (let x = -5; x < 220; x += 10) {
 		let n = ruido(t, x * 0.1);
-		círculo(x - 100, 0, n * 40);
+		circulo(x - 100, 0, n * 40);
 	}
 };
 ```
@@ -137,7 +137,7 @@ q5.dibujar = function () {
 	let t = millis() * 0.002;
 	for (let x = -100; x < 100; x += 5) {
 		for (let y = -100; y < 100; y += 5) {
-			relleno(ruido(t, (ratónX + x) * 0.05, y * 0.05));
+			relleno(ruido(t, (ratonX + x) * 0.05, y * 0.05));
 			cuadrado(x, y, 5);
 		}
 	}
@@ -150,17 +150,17 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 	let n = ruido(frameCount * 0.01);
-	círculo(100, 100, n * 200);
+	circulo(100, 100, n * 200);
 }
 ```
 
 ```js
 function dibujar() {
 	fondo(200);
-	let t = (frameCount + ratónX) * 0.02;
+	let t = (frameCount + ratonX) * 0.02;
 	for (let x = -5; x < 220; x += 10) {
 		let n = ruido(t, x * 0.1);
-		círculo(x, 100, n * 40);
+		circulo(x, 100, n * 40);
 	}
 }
 ```
@@ -184,9 +184,9 @@ Esta función también acepta dos objetos con propiedades `x` e `y`.
 ```js
 q5.dibujar = function () {
 	fondo(0.8);
-	línea(0, 0, ratónX, ratónY);
+	linea(0, 0, ratonX, ratonY);
 
-	let d = dist(0, 0, ratónX, ratónY);
+	let d = dist(0, 0, ratonX, ratonY);
 	texto(redondear(d), -80, -80);
 };
 ```
@@ -196,10 +196,10 @@ q5.dibujar = function () {
 ```js
 function dibujar() {
 	fondo(200);
-	círculo(100, 100, 20);
-	círculo(ratónX, ratónY, 20);
+	circulo(100, 100, 20);
+	circulo(ratonX, ratonY, 20);
 
-	let d = dist(100, 100, ratónX, ratónY);
+	let d = dist(100, 100, ratonX, ratonY);
 	texto(redondear(d), 20, 20);
 }
 ```
@@ -217,7 +217,7 @@ Mapea un número de un rango a otro.
 @returns {number} valor mapeado
 ```
 
-## modoÁngulo
+## modoAngulo
 
 Establece el modo para interpretar y dibujar ángulos. Puede ser 'degrees' (grados) o 'radians' (radianes).
 
@@ -389,8 +389,8 @@ Devuelve el valor más pequeño en una secuencia de números.
 
 ```js
 q5.dibujar = function () {
-	fondo(min(-ratónX / 100, 0.5));
-	círculo(min(ratónX, 0), 0, 80);
+	fondo(min(-ratonX / 100, 0.5));
+	circulo(min(ratonX, 0), 0, 80);
 };
 ```
 
@@ -398,8 +398,8 @@ q5.dibujar = function () {
 
 ```js
 function dibujar() {
-	fondo(min(ratónX, 100));
-	círculo(min(ratónX, 100), 0, 80);
+	fondo(min(ratonX, 100));
+	circulo(min(ratonX, 100), 0, 80);
 }
 ```
 
@@ -416,8 +416,8 @@ Devuelve el valor más grande en una secuencia de números.
 
 ```js
 q5.dibujar = function () {
-	fondo(max(-ratónX / 100, 0.5));
-	círculo(max(ratónX, 0), 0, 80);
+	fondo(max(-ratonX / 100, 0.5));
+	circulo(max(ratonX, 0), 0, 80);
 };
 ```
 
@@ -425,8 +425,8 @@ q5.dibujar = function () {
 
 ```js
 function dibujar() {
-	fondo(max(ratónX, 100));
-	círculo(max(ratónX, 100), 0, 80);
+	fondo(max(ratonX, 100));
+	circulo(max(ratonX, 100), 0, 80);
 }
 ```
 

--- a/lang/es/learn/record.md
+++ b/lang/es/learn/record.md
@@ -32,7 +32,7 @@ let grab = crearGrabadora();
 grab.bitrate = 10;
 
 q5.dibujar = function () {
-	círculo(ratónX, flu(medioAlto), 10);
+	circulo(ratonX, flu(medioAlto), 10);
 };
 ```
 
@@ -45,7 +45,7 @@ let grab = crearGrabadora();
 grab.bitrate = 10;
 
 function dibujar() {
-	círculo(ratónX, aleatorio(alto), 10);
+	circulo(ratonX, aleatorio(alto), 10);
 }
 ```
 
@@ -55,15 +55,15 @@ Comienza a grabar el lienzo o reanuda la grabación si estaba pausada.
 
 Si no existe grabadora, se crea una pero no se muestra.
 
-## pausarGrabación
+## pausarGrabacion
 
 Pausa la grabación del lienzo, si hay una en progreso.
 
-## borrarGrabación
+## borrarGrabacion
 
 Descarta la grabación actual.
 
-## guardarGrabación
+## guardarGrabacion
 
 Guarda la grabación actual como un archivo de video.
 
@@ -75,12 +75,12 @@ Guarda la grabación actual como un archivo de video.
 
 ```js
 q5.dibujar = function () {
-	cuadrado(ratónX, flu(100), 10);
+	cuadrado(ratonX, flu(100), 10);
 };
 
 q5.alPresionarRatón = function () {
 	if (!grabando) grabar();
-	else guardarGrabación('squares');
+	else guardarGrabacion('squares');
 };
 ```
 
@@ -88,12 +88,12 @@ q5.alPresionarRatón = function () {
 
 ```js
 function dibujar() {
-	cuadrado(ratónX, aleatorio(200), 10);
+	cuadrado(ratonX, aleatorio(200), 10);
 }
 
 function alPresionarRatón() {
 	if (!grabando) grabar();
-	else guardarGrabación('squares');
+	else guardarGrabacion('squares');
 }
 ```
 

--- a/lang/es/learn/shaders.md
+++ b/lang/es/learn/shaders.md
@@ -7,7 +7,7 @@ usados para crear efectos visuales avanzados en q5!
 
 Crea un shader que el renderizador WebGPU de q5 puede usar.
 
-Si `tipo` no se especifica, esta función personaliza una copia del [shader de formas por defecto](https://github.com/q5js/q5.js/blob/main/src/shaders/shapes.wgsl), lo que afecta a las siguientes funciones: `plano`, `línea`, y `terminarForma`.
+Si `tipo` no se especifica, esta función personaliza una copia del [shader de formas por defecto](https://github.com/q5js/q5.js/blob/main/src/shaders/shapes.wgsl), lo que afecta a las siguientes funciones: `plano`, `linea`, y `terminarForma`.
 
 Para más información sobre los parámetros de entrada de las funciones de vértice y fragmento,
 los datos y las funciones auxiliares disponibles para usar
@@ -160,8 +160,8 @@ fn fragMain(f: FragParams) -> @location(0) vec4f {
 q5.dibujar = function () {
 	trazo(1);
 	grosorTrazo(8);
-	línea(ratónX, ratónY, pRatónX, pRatónY);
-	ratónPresionado ? reiniciarShaders() : shader(boxy);
+	linea(ratonX, ratonY, pRatonX, pRatonY);
+	ratonPresionado ? reiniciarShaders() : shader(boxy);
 };
 ```
 
@@ -246,7 +246,7 @@ fn fragMain(f: FragParams) -> @location(0) vec4f {
 
 q5.dibujar = function () {
 	limpiar();
-	if (ratónPresionado) vid.play();
+	if (ratonPresionado) vid.play();
 	shader(flipper);
 	imagen(vid, -100, 150, 200, 150);
 };

--- a/lang/es/learn/shapes.md
+++ b/lang/es/learn/shapes.md
@@ -1,6 +1,6 @@
 # formas
 
-## círculo
+## circulo
 
 Dibuja un círculo en la posición (x, y) con el diámetro especificado.
 
@@ -14,14 +14,14 @@ Dibuja un círculo en la posición (x, y) con el diámetro especificado.
 
 ```js
 await Lienzo(200, 100);
-círculo(0, 0, 80);
+circulo(0, 0, 80);
 ```
 
 ### c2d
 
 ```js
 crearLienzo(200, 100);
-círculo(100, 50, 80);
+circulo(100, 50, 80);
 ```
 
 ## elipse
@@ -147,7 +147,7 @@ grosorTrazo(10);
 punto(125, 50);
 ```
 
-## línea
+## linea
 
 Dibuja una línea en el lienzo.
 
@@ -163,7 +163,7 @@ Dibuja una línea en el lienzo.
 ```js
 await Lienzo(200, 100);
 trazo('lime');
-línea(-80, -30, 80, 30);
+linea(-80, -30, 80, 30);
 ```
 
 ### c2d
@@ -171,10 +171,10 @@ línea(-80, -30, 80, 30);
 ```js
 crearLienzo(200, 100);
 trazo('lime');
-línea(20, 20, 180, 80);
+linea(20, 20, 180, 80);
 ```
 
-## cápsula
+## capsula
 
 Dibuja una cápsula.
 
@@ -192,7 +192,7 @@ Dibuja una cápsula.
 await Lienzo(200, 100);
 fondo(0.8);
 grosorTrazo(5);
-cápsula(-60, -10, 60, 10, 10);
+capsula(-60, -10, 60, 10, 10);
 ```
 
 ```js
@@ -200,7 +200,7 @@ q5.dibujar = function () {
 	fondo(0.8);
 	relleno('cyan');
 	grosorTrazo(10);
-	cápsula(0, 0, ratónX, ratónY, 20);
+	capsula(0, 0, ratonX, ratonY, 20);
 };
 ```
 
@@ -210,7 +210,7 @@ q5.dibujar = function () {
 crearLienzo(200, 100);
 fondo(200);
 grosorTrazo(5);
-cápsula(40, 40, 160, 60, 10);
+capsula(40, 40, 160, 60, 10);
 ```
 
 ```js
@@ -218,7 +218,7 @@ function dibujar() {
 	fondo(200);
 	relleno('cyan');
 	grosorTrazo(10);
-	cápsula(100, 100, ratónX, ratónY, 20);
+	capsula(100, 100, ratonX, ratonY, 20);
 }
 ```
 
@@ -314,7 +314,7 @@ rect(50, 25, 150, 75);
 Establecer a `CENTRO` (por defecto), `RADIO`, `ESQUINA`, o `ESQUINAS`.
 
 Cambia cómo se interpretan las primeras cuatro entradas para
-`elipse`, `círculo`, y `arco`.
+`elipse`, `circulo`, y `arco`.
 
 ```
 @param {string} modo

--- a/lang/es/learn/shaping.md
+++ b/lang/es/learn/shaping.md
@@ -82,7 +82,7 @@ Comienza a almacenar vértices para una forma convexa.
 
 Termina de almacenar vértices para una forma convexa.
 
-## vértice
+## vertice
 
 Especifica un vértice en una forma.
 
@@ -103,15 +103,15 @@ grosorTrazo(20);
 
 empezarForma();
 relleno(1, 0, 0);
-vértice(-80, -80);
-vértice(40, -60);
+vertice(-80, -80);
+vertice(40, -60);
 relleno(0, 0, 1);
-vértice(80, 60);
-vértice(-60, 80);
+vertice(80, 60);
+vertice(-60, 80);
 terminarForma(true);
 ```
 
-## vérticeBezier
+## verticeBezier
 
 Especifica un vértice Bezier en una forma.
 
@@ -124,7 +124,7 @@ Especifica un vértice Bezier en una forma.
 @param {number} y coordenada-y del punto de anclaje
 ```
 
-## vérticeCuadrático
+## verticeCuadratico
 
 Especifica un vértice Bezier cuadrático en una forma.
 
@@ -150,7 +150,7 @@ Dibuja una curva Bezier.
 @param {number} y4 coordenada-y del segundo punto de anclaje
 ```
 
-## triángulo
+## triangulo
 
 Dibuja un triángulo.
 

--- a/lang/es/learn/styles.md
+++ b/lang/es/learn/styles.md
@@ -19,7 +19,7 @@ await Lienzo(200);
 fondo(0.8);
 
 relleno('red');
-círculo(-20, -20, 80);
+circulo(-20, -20, 80);
 
 relleno('lime');
 cuadrado(-20, -20, 80);
@@ -32,7 +32,7 @@ crearLienzo(200);
 fondo(200);
 
 relleno('red');
-círculo(80, 80, 80);
+circulo(80, 80, 80);
 
 relleno('lime');
 cuadrado(80, 80, 80);
@@ -58,7 +58,7 @@ fondo(0.8);
 relleno(0.14);
 
 trazo('red');
-círculo(-20, -20, 80);
+circulo(-20, -20, 80);
 
 trazo('lime');
 cuadrado(-20, -20, 80);
@@ -72,7 +72,7 @@ fondo(200);
 relleno(36);
 
 trazo('red');
-círculo(80, 80, 80);
+circulo(80, 80, 80);
 
 trazo('lime');
 cuadrado(80, 80, 80);
@@ -91,7 +91,7 @@ fondo(0.8);
 sinRelleno();
 
 trazo('red');
-círculo(-20, -20, 80);
+circulo(-20, -20, 80);
 trazo('lime');
 cuadrado(-20, -20, 80);
 ```
@@ -105,7 +105,7 @@ fondo(200);
 sinRelleno();
 
 trazo('red');
-círculo(80, 80, 80);
+circulo(80, 80, 80);
 trazo('lime');
 cuadrado(80, 80, 80);
 ```
@@ -121,7 +121,7 @@ await Lienzo(200);
 fondo(0.8);
 relleno(0.14);
 trazo('red');
-círculo(-20, -20, 80);
+circulo(-20, -20, 80);
 
 sinTrazo();
 cuadrado(-20, -20, 80);
@@ -134,7 +134,7 @@ crearLienzo(200);
 fondo(200);
 relleno(36);
 trazo('red');
-círculo(80, 80, 80);
+circulo(80, 80, 80);
 
 sinTrazo();
 cuadrado(80, 80, 80);
@@ -154,10 +154,10 @@ Establece el tamaño del trazo usado para líneas y el borde alrededor de dibujo
 await Lienzo(200);
 fondo(0.8);
 trazo('red');
-círculo(-50, 0, 80);
+circulo(-50, 0, 80);
 
 grosorTrazo(12);
-círculo(50, 0, 80);
+circulo(50, 0, 80);
 ```
 
 ### c2d
@@ -166,10 +166,10 @@ círculo(50, 0, 80);
 crearLienzo(200);
 fondo(200);
 trazo('red');
-círculo(50, 100, 80);
+circulo(50, 100, 80);
 
 grosorTrazo(12);
-círculo(150, 100, 80);
+circulo(150, 100, 80);
 ```
 
 ## opacidad
@@ -189,7 +189,7 @@ await Lienzo(200);
 fondo(0.8);
 
 opacidad(1);
-círculo(-20, -20, 80);
+circulo(-20, -20, 80);
 
 opacidad(0.2);
 cuadrado(-20, -20, 80);
@@ -202,7 +202,7 @@ crearLienzo(200);
 fondo(200);
 
 opacidad(1);
-círculo(80, 80, 80);
+circulo(80, 80, 80);
 
 opacidad(0.2);
 cuadrado(80, 80, 80);
@@ -289,8 +289,8 @@ sombra(50);
 
 function dibujar() {
 	fondo(200);
-	cajaSombra(-20, ratónY, 10);
-	círculo(100, 100, 80, 80);
+	cajaSombra(-20, ratonY, 10);
+	circulo(100, 100, 80, 80);
 }
 ```
 
@@ -316,7 +316,7 @@ No disponible en q5 WebGPU.
 @param {string} val operación de composición
 ```
 
-## terminaciónTrazo
+## terminacionTrazo
 
 Establece el estilo de terminación de línea a `ROUND`, `SQUARE`, o `PROJECT`.
 
@@ -333,17 +333,17 @@ crearLienzo(200);
 fondo(200);
 grosorTrazo(20);
 
-terminaciónTrazo(ROUND);
-línea(50, 50, 150, 50);
+terminacionTrazo(ROUND);
+linea(50, 50, 150, 50);
 
-terminaciónTrazo(SQUARE);
-línea(50, 100, 150, 100);
+terminacionTrazo(SQUARE);
+linea(50, 100, 150, 100);
 
-terminaciónTrazo(PROJECT);
-línea(50, 150, 150, 150);
+terminacionTrazo(PROJECT);
+linea(50, 150, 150, 150);
 ```
 
-## uniónTrazo
+## unionTrazo
 
 Establece el estilo de unión de línea a `ROUND`, `BEVEL`, o `MITER`.
 
@@ -360,13 +360,13 @@ crearLienzo(200);
 fondo(200);
 grosorTrazo(10);
 
-uniónTrazo(ROUND);
+unionTrazo(ROUND);
 triángulo(50, 20, 150, 20, 50, 70);
 
-uniónTrazo(BEVEL);
+unionTrazo(BEVEL);
 triángulo(150, 50, 50, 100, 150, 150);
 
-uniónTrazo(MITER);
+unionTrazo(MITER);
 triángulo(50, 130, 150, 180, 50, 180);
 ```
 
@@ -404,10 +404,10 @@ fondo(0.8);
 
 guardarEstilos();
 relleno('blue');
-círculo(-50, -50, 80);
+circulo(-50, -50, 80);
 
 recuperarEstilos();
-círculo(50, 50, 80);
+circulo(50, 50, 80);
 ```
 
 ### c2d
@@ -418,10 +418,10 @@ fondo(200);
 
 guardarEstilos();
 relleno('blue');
-círculo(50, 50, 80);
+circulo(50, 50, 80);
 
 recuperarEstilos();
-círculo(150, 150, 80);
+circulo(150, 150, 80);
 ```
 
 ## recuperarEstilos
@@ -436,10 +436,10 @@ fondo(0.8);
 
 guardarEstilos();
 relleno('blue');
-círculo(-50, -50, 80);
+circulo(-50, -50, 80);
 
 recuperarEstilos();
-círculo(50, 50, 80);
+circulo(50, 50, 80);
 ```
 
 ### c2d
@@ -450,10 +450,10 @@ fondo(200);
 
 guardarEstilos();
 relleno('blue');
-círculo(50, 50, 80);
+circulo(50, 50, 80);
 
 recuperarEstilos();
-círculo(150, 150, 80);
+circulo(150, 150, 80);
 ```
 
 ## limpiar
@@ -469,7 +469,7 @@ await Lienzo(200, { alpha: true });
 
 q5.dibujar = function () {
 	limpiar();
-	círculo((frameCount % 200) - 100, 0, 80);
+	circulo((frameCount % 200) - 100, 0, 80);
 };
 ```
 
@@ -480,7 +480,7 @@ crearLienzo(200, 200, { alpha: true });
 
 function dibujar() {
 	limpiar();
-	círculo(frameCount % 200, 100, 80);
+	circulo(frameCount % 200, 100, 80);
 }
 ```
 

--- a/lang/es/learn/text.md
+++ b/lang/es/learn/text.md
@@ -218,7 +218,7 @@ Establece u obtiene el tamaño de fuente actual. Si no se proporciona argumento,
 q5.dibujar = function () {
 	fondo(0.8);
 
-	tamañoTexto(abs(ratónX));
+	tamañoTexto(abs(ratonX));
 	texto('A', -90, 90);
 };
 ```
@@ -229,7 +229,7 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 
-	tamañoTexto(abs(ratónX));
+	tamañoTexto(abs(ratonX));
 	texto('A', 10, 190);
 }
 ```
@@ -249,7 +249,7 @@ Establece u obtiene la altura de línea actual. Si no se proporciona argumento, 
 q5.dibujar = function () {
 	fondo(0.8);
 
-	tamañoTexto(abs(ratónX));
+	tamañoTexto(abs(ratonX));
 	texto('A', -90, 90);
 	rect(-90, 90, 5, -interlineado());
 };
@@ -261,7 +261,7 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 
-	tamañoTexto(abs(ratónX));
+	tamañoTexto(abs(ratonX));
 	texto('A', 10, 190);
 	rect(10, 190, 5, -interlineado());
 }
@@ -301,7 +301,7 @@ tamañoTexto(32);
 texto('Hello, world!', 12, 106);
 ```
 
-## alineaciónTexto
+## alineacionTexto
 
 Establece la alineación horizontal y vertical del texto.
 
@@ -317,7 +317,7 @@ await Lienzo(200);
 fondo(0.8);
 tamañoTexto(32);
 
-alineaciónTexto(CENTRO, MEDIO);
+alineacionTexto(CENTRO, MEDIO);
 texto('Hello, world!', 0, 0);
 ```
 
@@ -328,7 +328,7 @@ crearLienzo(200);
 fondo(200);
 tamañoTexto(32);
 
-alineaciónTexto(CENTRO, MEDIO);
+alineacionTexto(CENTRO, MEDIO);
 texto('Hello, world!', 100, 100);
 ```
 
@@ -356,7 +356,7 @@ Establece el peso del texto.
 await Lienzo(200);
 fondo(0.8);
 tamañoTexto(32);
-alineaciónTexto(CENTRO, MEDIO);
+alineacionTexto(CENTRO, MEDIO);
 
 pesoTexto(100);
 texto('Hello, world!', 0, 0);
@@ -368,7 +368,7 @@ texto('Hello, world!', 0, 0);
 crearLienzo(200);
 fondo(200);
 tamañoTexto(32);
-alineaciónTexto(CENTRO, MEDIO);
+alineacionTexto(CENTRO, MEDIO);
 
 pesoTexto(100);
 texto('Hello, world!', 100, 100);
@@ -389,7 +389,7 @@ Calcula y devuelve el ancho de una cadena de texto dada.
 q5.dibujar = function () {
 	fondo(0.8);
 
-	tamañoTexto(abs(ratónX));
+	tamañoTexto(abs(ratonX));
 	rect(-90, 90, anchoTexto('A'), -interlineado());
 	texto('A', -90, 90);
 };
@@ -401,7 +401,7 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 
-	tamañoTexto(abs(ratónX));
+	tamañoTexto(abs(ratonX));
 	rect(10, 190, anchoTexto('A'), -interlineado());
 	texto('A', 10, 190);
 }
@@ -422,7 +422,7 @@ Calcula y devuelve el ascenso (la distancia desde la línea base hasta la parte 
 q5.dibujar = function () {
 	fondo(0.8);
 
-	tamañoTexto(abs(ratónX));
+	tamañoTexto(abs(ratonX));
 	rect(-90, 90, anchoTexto('A'), -ascensoTexto());
 	texto('A', -90, 90);
 };
@@ -434,7 +434,7 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 
-	tamañoTexto(abs(ratónX));
+	tamañoTexto(abs(ratonX));
 	rect(10, 190, anchoTexto('A'), -ascensoTexto());
 	texto('A', 10, 190);
 }
@@ -537,7 +537,7 @@ un costo de rendimiento muy alto.
 await Lienzo(200);
 fondo(0.8);
 tamañoTexto(96);
-alineaciónTexto(CENTRO, CENTRO);
+alineacionTexto(CENTRO, CENTRO);
 
 imagenTexto('🐶', 0, 0);
 ```
@@ -558,7 +558,7 @@ imagenTexto('Hello!', -100, 100);
 crearLienzo(200);
 fondo(200);
 tamañoTexto(96);
-alineaciónTexto(CENTRO, CENTRO);
+alineacionTexto(CENTRO, CENTRO);
 
 imagenTexto('🐶', 100, 100);
 ```

--- a/lang/es/learn/transforms.md
+++ b/lang/es/learn/transforms.md
@@ -16,7 +16,7 @@ q5.dibujar = function () {
 	fondo(0.8);
 
 	trasladar(50, 50);
-	círculo(0, 0, 80);
+	circulo(0, 0, 80);
 };
 ```
 
@@ -27,7 +27,7 @@ function dibujar() {
 	fondo(200);
 
 	trasladar(150, 150);
-	círculo(0, 0, 80);
+	circulo(0, 0, 80);
 }
 ```
 
@@ -45,7 +45,7 @@ Rota el contexto de dibujo.
 q5.dibujar = function () {
 	fondo(0.8);
 
-	rotar(ratónX / 50);
+	rotar(ratonX / 50);
 
 	modoRect(CENTER);
 	cuadrado(0, 0, 120);
@@ -59,7 +59,7 @@ function dibujar() {
 	fondo(200);
 
 	trasladar(100, 100);
-	rotar(ratónX / 50);
+	rotar(ratonX / 50);
 
 	modoRect(CENTER);
 	cuadrado(0, 0, 50);
@@ -84,8 +84,8 @@ el contexto de dibujo se escalará uniformemente.
 q5.dibujar = function () {
 	fondo(0.8);
 
-	escalar(ratónX / 10);
-	círculo(0, 0, 20);
+	escalar(ratonX / 10);
+	circulo(0, 0, 20);
 };
 ```
 
@@ -95,8 +95,8 @@ q5.dibujar = function () {
 function dibujar() {
 	fondo(200);
 
-	escalar(ratónX / 10);
-	círculo(0, 0, 20);
+	escalar(ratonX / 10);
+	circulo(0, 0, 20);
 }
 ```
 
@@ -115,7 +115,7 @@ q5.dibujar = function () {
 	fondo(0.8);
 
 	trasladar(-75, -40);
-	cizallarX(ratónX / 100);
+	cizallarX(ratonX / 100);
 	cuadrado(0, 0, 80);
 };
 ```
@@ -127,7 +127,7 @@ function dibujar() {
 	fondo(200);
 
 	trasladar(25, 60);
-	cizallarX(ratónX / 100);
+	cizallarX(ratonX / 100);
 	cuadrado(0, 0, 80);
 }
 ```
@@ -147,7 +147,7 @@ q5.dibujar = function () {
 	fondo(0.8);
 
 	trasladar(-75, -40);
-	cizallarY(ratónX / 100);
+	cizallarY(ratonX / 100);
 	cuadrado(0, 0, 80);
 };
 ```
@@ -159,7 +159,7 @@ function dibujar() {
 	fondo(200);
 
 	trasladar(25, 60);
-	cizallarY(ratónX / 100);
+	cizallarY(ratonX / 100);
 	cuadrado(0, 0, 80);
 }
 ```
@@ -190,7 +190,7 @@ q5.dibujar = function () {
 	fondo(0.8);
 
 	aplicarMatriz(2, -1, 1, -1);
-	círculo(0, 0, 80);
+	circulo(0, 0, 80);
 };
 ```
 
@@ -201,7 +201,7 @@ function dibujar() {
 	fondo(200);
 
 	aplicarMatriz(2, 1, 1, 1, 100, 100);
-	círculo(0, 0, 80);
+	circulo(0, 0, 80);
 }
 ```
 
@@ -219,7 +219,7 @@ await Lienzo(200);
 fondo(0.8);
 
 trasladar(50, 50);
-círculo(0, 0, 80);
+circulo(0, 0, 80);
 
 reiniciarMatriz();
 cuadrado(0, 0, 50);
@@ -232,7 +232,7 @@ crearLienzo(200);
 fondo(200);
 
 trasladar(100, 100);
-círculo(0, 0, 80);
+circulo(0, 0, 80);
 
 reiniciarMatriz();
 cuadrado(0, 0, 50);
@@ -316,7 +316,7 @@ await Lienzo(200);
 apilar();
 relleno('blue');
 trasladar(50, 50);
-círculo(0, 0, 80);
+circulo(0, 0, 80);
 desapilar();
 
 cuadrado(0, 0, 50);
@@ -330,7 +330,7 @@ crearLienzo(200);
 apilar();
 relleno('blue');
 trasladar(100, 100);
-círculo(0, 0, 80);
+circulo(0, 0, 80);
 desapilar();
 
 cuadrado(0, 0, 50);
@@ -348,7 +348,7 @@ await Lienzo(200);
 apilar();
 relleno('blue');
 trasladar(50, 50);
-círculo(0, 0, 80);
+circulo(0, 0, 80);
 desapilar();
 
 cuadrado(0, 0, 50);
@@ -362,7 +362,7 @@ crearLienzo(200);
 apilar();
 relleno('blue');
 trasladar(100, 100);
-círculo(0, 0, 80);
+circulo(0, 0, 80);
 desapilar();
 
 cuadrado(0, 0, 50);

--- a/lang/es/learn/utilities.md
+++ b/lang/es/learn/utilities.md
@@ -89,7 +89,7 @@ un archivo de imagen llamado "untitled.png".
 ```js
 await Lienzo(200);
 fondo(0.8);
-círculo(0, 0, 50);
+circulo(0, 0, 50);
 
 q5.alPresionarRatón = function () {
 	guardar('circle.png');
@@ -113,7 +113,7 @@ q5.alPresionarRatón = function () {
 ```js
 crearLienzo(200);
 fondo(200);
-círculo(100, 100, 50);
+circulo(100, 100, 50);
 
 function alPresionarRatón() {
 	guardar('circle.png');
@@ -273,7 +273,7 @@ Devuelve el año actual.
 @returns {number} año actual
 ```
 
-## día
+## dia
 
 Devuelve el día actual del mes.
 

--- a/lang/es/learn/vector.md
+++ b/lang/es/learn/vector.md
@@ -19,7 +19,7 @@ await Lienzo(200);
 fondo(0.8);
 
 let v = crearVector(0, 0);
-círculo(v.x, v.y, 50);
+circulo(v.x, v.y, 50);
 ```
 
 ## Vector.constructor


### PR DESCRIPTION
remove accents from Spanish type definitions and review documentation to remove them from titles and code examples for consistency with API naming