### PR TITLE
fix: ensure `setup` is called with `this`

### DIFF
--- a/src/q5-core.js
+++ b/src/q5-core.js
@@ -308,9 +308,9 @@ function Q5(scope, parent, renderer) {
 
 	function wrapWithFES(name) {
 		const fn = t[name] || $[name];
-		$[name] = (event) => {
+		$[name] = function(...args) {
 			try {
-				return fn.call($, event);
+				return fn.apply(this, args);
 			} catch (e) {
 				if ($._fes) $._fes(e);
 				throw e;

--- a/src/q5-core.js
+++ b/src/q5-core.js
@@ -310,7 +310,7 @@ function Q5(scope, parent, renderer) {
 		const fn = t[name] || $[name];
 		$[name] = (event) => {
 			try {
-				return fn(event);
+				return fn.call($, event);
 			} catch (e) {
 				if ($._fes) $._fes(e);
 				throw e;


### PR DESCRIPTION
Fixes "this is undefined" errors from `setup` and the like.

Looks like the regression for `setup` was introduced in [3.2.6](https://github.com/q5js/q5.js/commit/576b71ed641ebd9fee88b38e2936fdacc84e579a), though `wrapWithFES` was introduced earlier than that and applied to different functions at various times.