### PR TITLE
deps: add terser as dev dependency, and let skia-canvas run its install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
 		"jest-cli": "^29.7.0",
 		"jsdom": "^25.0.1",
 		"json2csv": "^6.0.0-alpha.2",
-		"skia-canvas": "^1.0.2"
-	}
+		"skia-canvas": "^1.0.2",
+		"terser": "^5.46.1"
+	},
+	"trustedDependencies": [
+		"skia-canvas"
+	]
 }


### PR DESCRIPTION
`min` uses terser, which wasn't in the dependencies.

the tests failed to use skia-canvas unless I let it run its install script.