### PR TITLE
fix: don't use q5-server as the default export to browsers

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,9 +7,11 @@ fonts
 home
 lang
 learn
+teach
 src
 node_modules
 test
+.prettierignore
 p5-test
 package-lock.json
 .vscode
@@ -17,6 +19,7 @@ package-lock.json
 index.html
 jsconfig.json
 CODE_OF_CONDUCT.md
+bun.lock
 bun.lockb
 deno.lock
 q5js_brand.avif

--- a/package.json
+++ b/package.json
@@ -12,8 +12,27 @@
 	],
 	"license": "LGPL-3.0-only",
 	"homepage": "https://q5js.org/home",
-	"main": "q5-server.js",
 	"types": "q5.d.ts",
+	"browser": {
+		".": "./q5.min.js",
+		"node:process": false
+	},
+	"exports": {
+		".": {
+			"types": "./q5.d.ts",
+			"browser": "./q5.min.js",
+			"deno": "./q5-deno-server.js",
+			"node": "./q5-server.js",
+			"default": "./q5.min.js"
+		},
+		"./q5.min.js": "./q5.min.js",
+		"./q5.js": "./q5.js",
+		"./q5-server.js": {
+			"browser": null,
+			"deno": "./q5-deno-server.js",
+			"default": "./q5-server.js"
+		}
+	},
 	"funding": [
 		{
 			"type": "patreon",


### PR DESCRIPTION
When I went to load q5 from [esm.sh](https://esm.sh), I found that it was sending `q5-server.js` by default, which isn't what anyone wants in a browser.

(The advantage of using a service like esm.sh instead of loading direct from q5js.org is that I can specify the version number.)

I came across a couple mechanisms here:

[`exports` in `package.json`](https://nodejs.org/api/packages.html#package-entry-points) replaces `main` and allows the resolution to be conditional based on the environment.

But even after getting esm.sh to serve q5.js instead of q5-server.js, it was still pulling in something for `process` in an eager attempt to polyfill for the `Q5._server` detection here: https://github.com/q5js/q5.js/blob/6830a9ac7379b1adccdb5a9988e32c01c368699b/src/q5-core.js#L391

Turns out that polyfill can be disabled by adding an entry to [`browser`](https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module).

## Considerations

Defining `exports` has the potential to break things! I think I got it right but I haven't actually published it to npm/jsr and tried loading this version from there with node/bun/deno.

[jsDelivr](https://www.jsdelivr.com/documentation#id-configuring-a-default-file-in-packagejson) might be implemented differently than esm.sh.

It's debatable whether the `default` should be the server version or not, though the [node docs](https://nodejs.org/api/packages.html#conditional-exports) suggest that specifying `node` for server and `default` for other might be more reliable than assuming `browser` will be set by other tools.

Also maybe some question about whether the export should be the minified version.