### PR TITLE
Updated q5.js to dynamically set q5's WebGPU renderer format

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -1,3 +1,5 @@
+const DEVICE_FORMAT = navigator.gpu.getPreferredCanvasFormat();
+
 /**
  * q5.js
  * @version 4.7
@@ -6,7 +8,7 @@
  * @license LGPL-3.0
  * @class Q5
  */
-function Q5(scope, parent, renderer) {
+export function Q5(scope, parent, renderer) {
 	let $ = this;
 	$._isQ5 = $._q5 = true;
 	$._parent = parent;
@@ -5510,7 +5512,7 @@ struct Q5 {
 		let w = $.canvas.width,
 			h = $.canvas.height,
 			size = [w, h],
-			format = 'bgra8unorm';
+			format = DEVICE_FORMAT;
 
 		mainView = Q5.device
 			.createTexture({
@@ -6608,7 +6610,7 @@ fn fragMain(f: FragParams) -> @location(0) vec4f {
 		fragment: {
 			module: shapesShader,
 			entryPoint: 'fragMain',
-			targets: [{ format: 'bgra8unorm', blend: $.blendConfigs['source-over'] }]
+			targets: [{ format: DEVICE_FORMAT, blend: $.blendConfigs['source-over'] }]
 		},
 		primitive: { topology: 'triangle-strip', stripIndexFormat: 'uint32' },
 		multisample: { count: 4 }
@@ -7170,7 +7172,7 @@ fn vertexMain(v: VertexParams) -> FragParams {
 			entryPoint: 'fragMain',
 			targets: [
 				{
-					format: 'bgra8unorm',
+					format: DEVICE_FORMAT,
 					blend: $.blendConfigs['source-over']
 				}
 			]
@@ -7532,7 +7534,7 @@ fn fragMain(f: FragParams) -> @location(0) vec4f {
 			entryPoint: 'fragMain',
 			targets: [
 				{
-					format: 'bgra8unorm',
+					format: DEVICE_FORMAT,
 					blend: $.blendConfigs['source-over']
 				}
 			]
@@ -7805,7 +7807,7 @@ fn fragMain(f: FragParams) -> @location(0) vec4f {
 		fragment: {
 			module: imageShader,
 			entryPoint: 'fragMain',
-			targets: [{ format: 'bgra8unorm', blend: $.blendConfigs['source-over'] }]
+			targets: [{ format: DEVICE_FORMAT, blend: $.blendConfigs['source-over'] }]
 		},
 		primitive: { topology: 'triangle-strip', stripIndexFormat: 'uint32' },
 		multisample: { count: 4 }
@@ -7824,7 +7826,7 @@ fn fragMain(f: FragParams) -> @location(0) vec4f {
 		fragment: {
 			module: videoShader,
 			entryPoint: 'fragMain',
-			targets: [{ format: 'bgra8unorm', blend: $.blendConfigs['source-over'] }]
+			targets: [{ format: DEVICE_FORMAT, blend: $.blendConfigs['source-over'] }]
 		},
 		primitive: { topology: 'triangle-strip', stripIndexFormat: 'uint32' },
 		multisample: { count: 4 }
@@ -7922,7 +7924,7 @@ fn fragMain(f: FragParams) -> @location(0) vec4f {
 
 			texture = Q5.device.createTexture({
 				size: textureSize,
-				format: 'bgra8unorm',
+				format: DEVICE_FORMAT,
 				usage:
 					GPUTextureUsage.TEXTURE_BINDING |
 					GPUTextureUsage.COPY_SRC |
@@ -8294,7 +8296,7 @@ fn fragMain(f : FragParams) -> @location(0) vec4f {
 		fragment: {
 			module: textShader,
 			entryPoint: 'fragMain',
-			targets: [{ format: 'bgra8unorm', blend: $.blendConfigs['source-over'] }]
+			targets: [{ format: DEVICE_FORMAT, blend: $.blendConfigs['source-over'] }]
 		},
 		primitive: { topology: 'triangle-strip', stripIndexFormat: 'uint32' },
 		multisample: { count: 4 }
@@ -8858,7 +8860,7 @@ fn fragMain(f : FragParams) -> @location(0) vec4f {
 				entryPoint: 'fragMain',
 				targets: [
 					{
-						format: 'bgra8unorm',
+						format: DEVICE_FORMAT,
 						blend: $.blendConfigs[blend]
 					}
 				]


### PR DESCRIPTION
q5's WebGPU renderer hardcodes 'bgra8unorm' in its render pipeline/attachments. On Android Chrome, navigator.gpu.getPreferredCanvasFormat() returns 'rgba8unorm', causing a validation error:

"resolve target format RGBA8Unorm does not match color attachment BGRA8Unorm"

Replacing the hardcoded format with navigator.gpu.getPreferredCanvasFormat() (stored in DEVICE_FORMAT at the top of the file) resolves the issue on Android while continuing to work on desktop. You should see DEVICE_FORMAT everywhere that 'bgra8unorm' previously was. I haven't tested if this breaks any other renderers but it has made q5.js compatible with both desktop and my S25 Edge.